### PR TITLE
Add support for lineDash property for accessibility

### DIFF
--- a/examples/example-dashed-line.html
+++ b/examples/example-dashed-line.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="text/javascript" src="../smoothie.js"></script>
+    <script type="text/javascript">
+      // Randomly add a data point every 500ms
+      var random = new TimeSeries();
+      setInterval(function () {
+        random.append(Date.now(), Math.random() * 10000);
+      }, 500);
+
+      function createTimeline() {
+        var chart = new SmoothieChart({tooltipLine:{strokeStyle:'#bbbbbb'},minValue:-10000,maxValue:10000}),
+        canvas = document.getElementById('smoothie-chart'),
+        series = new TimeSeries();
+
+        chart.addTimeSeries(random, {lineWidth:2,strokeStyle:'#00ff00',interpolation:'linear', lineDash: [10, 5]});
+        chart.streamTo(canvas, 500);
+      }
+    </script>
+  </head>
+  <body onload="createTimeline()" style="background-color: #333333">
+    <canvas id="smoothie-chart" width="500" height="100">
+  </body>
+</html>

--- a/smoothie.d.ts
+++ b/smoothie.d.ts
@@ -10,6 +10,10 @@ export interface ITimeSeriesOptions {
 
 export interface ITimeSeriesPresentationOptions {
     strokeStyle?: string;
+    /**
+     * Only supported for charts using fixed axes and linear interpolation.
+     */
+    lineDash?: [number, number];
     fillStyle?: string;
     lineWidth?: number;
     /**
@@ -53,6 +57,12 @@ export declare class TimeSeries {
     maxValue: number;
 
     /**
+     * Used to maintain a consistent lineDash if used.
+     */
+    lineDashOffset: number;
+    
+    /**
+     * 
      * Hide this <code>TimeSeries</code> object in the chart.
      */
     disabled: boolean;


### PR DESCRIPTION
Currently only supported for charts using a fixed y-axis and linear interpolation.

Variation in axis height and different methods of interpolation affect the lineDashOffset property which represents the length of the line that overflows the canvas produced from old data.

A new example has been added to demonstrate the feature.